### PR TITLE
🎨 Fix brand consistency: Update header gradient to green theme

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,11 +31,11 @@ export default function RootLayout({
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="flex justify-between items-center py-8">
               <div className="flex items-center space-x-4">
-                <div className="w-12 h-12 bg-gradient-to-br from-purple-500 to-pink-500 rounded-2xl flex items-center justify-center shadow-lg transform rotate-3 hover:rotate-0 transition-transform duration-300">
+                <div className="w-12 h-12 bg-gradient-to-br from-emerald-500 to-green-500 rounded-2xl flex items-center justify-center shadow-lg transform rotate-3 hover:rotate-0 transition-transform duration-300">
                   <span className="text-2xl">📚</span>
                 </div>
                 <div>
-                  <h1 className="text-3xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
+                  <h1 className="text-3xl font-bold bg-gradient-to-r from-emerald-600 to-green-600 bg-clip-text text-transparent">
                     Kindle書籍コレクション
                   </h1>
                   <p className="text-base text-gray-600 mt-1 font-medium">
@@ -63,7 +63,7 @@ export default function RootLayout({
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
             <div className="text-center">
               <div className="inline-flex items-center space-x-2 mb-4">
-                <div className="w-8 h-8 bg-gradient-to-br from-purple-500 to-pink-500 rounded-lg flex items-center justify-center">
+                <div className="w-8 h-8 bg-gradient-to-br from-emerald-500 to-green-500 rounded-lg flex items-center justify-center">
                   <span className="text-lg">📚</span>
                 </div>
                 <span className="text-lg font-semibold text-gray-800">Kindle書籍コレクション</span>


### PR DESCRIPTION
## Summary
- Changed header icon gradient from purple/pink to emerald/green
- Updated main title gradient from purple/pink to emerald/green
- Updated footer icon gradient from purple/pink to emerald/green
- Ensures consistent green theme throughout the entire site

## Test plan
- [x] Visual inspection of header elements
- [x] Verify footer gradient consistency
- [x] Confirm no other purple/pink gradients remain
- [x] Test on development server (localhost:3001)

🤖 Generated with [Claude Code](https://claude.ai/code)